### PR TITLE
Add @netlify/angular-runtime for Angular 19 SSR support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/platform-server": "^19.2.21",
         "@angular/router": "^19.2.21",
         "@angular/ssr": "^19.2.25",
+        "@netlify/angular-runtime": "^3.0.1",
         "express": "^4.18.2",
         "normalize.css": "^8.0.1",
         "rxjs": "~7.8.0",
@@ -4634,6 +4635,54 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@netlify/angular-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/angular-runtime/-/angular-runtime-3.0.1.tgz",
+      "integrity": "sha512-YNUkX7uY5ENNnoZu5Vlk9LAIqRUBsgp9md2InGMbRLUg8CKjMrOCwm2ZXYfuCWITwI9slE2EBQtN+len/C7wdA==",
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=18.13.0"
+      }
+    },
+    "node_modules/@netlify/angular-runtime/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@netlify/angular-runtime/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@netlify/angular-runtime/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@ngtools/webpack": {
       "version": "19.2.25",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.25.tgz",
@@ -8944,8 +8993,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -12692,7 +12740,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-server": "^19.2.21",
     "@angular/router": "^19.2.21",
     "@angular/ssr": "^19.2.25",
+    "@netlify/angular-runtime": "^3.0.1",
     "express": "^4.18.2",
     "normalize.css": "^8.0.1",
     "rxjs": "~7.8.0",


### PR DESCRIPTION
This change adds the `@netlify/angular-runtime` package to the project's dependencies. This is required for Angular 19 Server-Side Rendering (SSR) to work correctly on Netlify. Without this package, Netlify's build process fails with an error indicating that the runtime is missing.

I have:
1. Installed `@netlify/angular-runtime@^3.0.1`.
2. Verified the installation in `package.json` and `package-lock.json`.
3. Verified that the project still builds locally using `npm run build`.
4. Verified that all existing unit tests pass.

---
*PR created automatically by Jules for task [3411285745578099507](https://jules.google.com/task/3411285745578099507) started by @snapfast*