### PR TITLE
Improve words component layout and behavior

### DIFF
--- a/src/app/component/words/words.component.css
+++ b/src/app/component/words/words.component.css
@@ -115,10 +115,10 @@
 .knowledge-fragment {
   position: absolute;
   z-index: 100;
-  transform: translate(10px, 10px);
+  transform: translate(60px, 60px);
   pointer-events: none;
   animation: fragmentAppear 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
-  max-width: calc(100vw - 40px);
+  max-width: calc(100vw - 120px);
 }
 
 .fragment-content {
@@ -201,6 +201,6 @@
   }
   to {
     opacity: 1;
-    transform: translate(10px, 10px) scale(1);
+    transform: translate(60px, 60px) scale(1);
   }
 }

--- a/src/app/component/words/words.component.html
+++ b/src/app/component/words/words.component.html
@@ -51,8 +51,4 @@
     </div>
   }
 
-  <button class="refresh-btn" (click)="refreshWords($event)">
-    <span class="material-symbols-outlined">refresh</span>
-    Discover New Roots
-  </button>
 </div>

--- a/src/app/component/words/words.component.ts
+++ b/src/app/component/words/words.component.ts
@@ -117,15 +117,9 @@ export class WordsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.refreshWords();
-    if (isPlatformBrowser(this.platformId)) {
-      this.refreshInterval = setInterval(() => this.refreshWords(), 15000);
-    }
   }
 
   ngOnDestroy() {
-    if (this.refreshInterval) {
-      clearInterval(this.refreshInterval);
-    }
   }
 
   refreshWords(event?: MouseEvent) {
@@ -163,38 +157,12 @@ export class WordsComponent implements OnInit, OnDestroy {
         updatedFragments.set(word.id, { word, etymology, tokens, isLoading: false });
         this.activeFragments.set(updatedFragments);
       }
-
-      const parts = etymology.split(/\s+/)
-        .map(w => w.replace(/[.,();]/g, '').toLowerCase())
-        .filter(w => w.length > 3 && /^[a-z]+$/.test(w));
-
-      const uniqueLinks = Array.from(new Set(parts))
-        .filter(w => !this.displayedWords().some(dw => dw.text === w))
-        .sort((a, b) => b.length - a.length) // Pick longer words as they are often more interesting etymologically
-        .slice(0, 6);
-
-      // Add linked words around the clicked word
-      const newWords: WordNode[] = uniqueLinks.map((w, i) => {
-        const angle = (i / uniqueLinks.length) * 2 * Math.PI;
-        const radius = 15;
-        return {
-          text: w,
-          x: Math.max(10, Math.min(90, word.x + Math.cos(angle) * radius)),
-          y: Math.max(10, Math.min(85, word.y + Math.sin(angle) * radius)),
-          id: this.nextId++,
-          parentId: word.id
-        };
-      });
-
-      const current = this.displayedWords();
-      // Only keep the last 50 words to prevent performance issues but allow longer paths
-      this.displayedWords.set([...current, ...newWords].slice(-50));
     });
   }
 
   isClickable(token: string): boolean {
     const clean = token.replace(/[.,();]/g, '').toLowerCase();
-    return clean.length > 3 && /^[a-z]+$/.test(clean);
+    return clean.length > 3 && /^[a-z]+$/.test(clean) && this.displayedWords().some(w => w.text === clean);
   }
 
   handleTokenClick(token: string, parentWord: WordNode, event: MouseEvent) {
@@ -202,23 +170,11 @@ export class WordsComponent implements OnInit, OnDestroy {
     const clean = token.replace(/[.,();]/g, '').toLowerCase();
 
     // Check if the word is already on the board
-    let existing = this.displayedWords().find(w => w.text === clean);
+    const existing = this.displayedWords().find(w => w.text === clean);
 
-    if (!existing) {
-      // Create it near the parent
-      const angle = Math.random() * 2 * Math.PI;
-      const radius = 12;
-      existing = {
-        text: clean,
-        x: Math.max(10, Math.min(90, parentWord.x + Math.cos(angle) * radius)),
-        y: Math.max(10, Math.min(85, parentWord.y + Math.sin(angle) * radius)),
-        id: this.nextId++,
-        parentId: parentWord.id
-      };
-      this.displayedWords.set([...this.displayedWords(), existing].slice(-50));
+    if (existing) {
+      this.handleWordClick(existing, event, true);
     }
-
-    this.handleWordClick(existing, event, true);
   }
 
   closeFragment(id?: number) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,7 +11,7 @@
   --border-color: #e0e0e0;
   --error-color: #c62828;
   --success-color: #2e7d32;
-  --max-width: 900px;
+  --max-width: 1200px;
   --shadow: 0 2px 10px rgba(0,0,0,0.05);
   --border-radius: 8px;
 }


### PR DESCRIPTION
This PR addresses three layout and behavior improvements in the words component:
1. Increased the offset distance between word nodes and their corresponding etymology cards to 60px.
2. Modified the component to be static; removed automatic refreshing, the manual refresh button, and the dynamic addition of new words upon interaction.
3. Expanded the overall website width by increasing the --max-width CSS variable to 1200px.

---
*PR created automatically by Jules for task [961486739006506335](https://jules.google.com/task/961486739006506335) started by @snapfast*