### PR TITLE
⚡ Implement HTTP Caching in EtymologyService

### DIFF
--- a/src/app/service/etymology.service.spec.ts
+++ b/src/app/service/etymology.service.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { EtymologyService } from './etymology.service';
+
+describe('EtymologyService', () => {
+  let service: EtymologyService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        EtymologyService
+      ]
+    });
+    service = TestBed.inject(EtymologyService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch etymology and cache it (to be implemented)', () => {
+    const word = 'test';
+    const mockResponse = {
+      query: {
+        pages: {
+          '123': {
+            extract: '== English ==\n=== Etymology ===\nTest etymology.'
+          }
+        }
+      }
+    };
+
+    // First call
+    service.getEtymology(word).subscribe(res => {
+      expect(res).toBe('Test etymology.');
+    });
+
+    const req1 = httpMock.expectOne(req => req.url === 'https://en.wiktionary.org/w/api.php' && req.params.get('titles') === word);
+    expect(req1.request.method).toBe('GET');
+    req1.flush(mockResponse);
+
+    // Second call - should use cache
+    service.getEtymology(word).subscribe(res => {
+      expect(res).toBe('Test etymology.');
+    });
+
+    // If caching is NOT implemented, this will fail because httpMock.verify() will see an outstanding request
+    // Or we can try to expectOne again and it should fail if we don't want a second request.
+    httpMock.expectNone(req => req.url === 'https://en.wiktionary.org/w/api.php' && req.params.get('titles') === word);
+  });
+});

--- a/src/app/service/etymology.service.ts
+++ b/src/app/service/etymology.service.ts
@@ -1,16 +1,23 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, map } from 'rxjs';
+import { Observable, map, shareReplay } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class EtymologyService {
   private apiUrl = 'https://en.wiktionary.org/w/api.php';
+  private cache = new Map<string, Observable<string>>();
 
   constructor(private http: HttpClient) {}
 
   getEtymology(word: string): Observable<string> {
+    const cacheKey = word.toLowerCase().trim();
+
+    if (this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey)!;
+    }
+
     const params = {
       action: 'query',
       prop: 'extracts',
@@ -20,7 +27,7 @@ export class EtymologyService {
       origin: '*'
     };
 
-    return this.http.get<any>(this.apiUrl, { params }).pipe(
+    const request$ = this.http.get<any>(this.apiUrl, { params }).pipe(
       map(response => {
         const pages = response.query.pages;
         const pageId = Object.keys(pages)[0];
@@ -29,8 +36,12 @@ export class EtymologyService {
         }
         const extract = pages[pageId].extract;
         return this.parseEtymology(extract);
-      })
+      }),
+      shareReplay(1)
     );
+
+    this.cache.set(cacheKey, request$);
+    return request$;
   }
 
   private parseEtymology(extract: string): string {


### PR DESCRIPTION
This change implements HTTP caching in the `EtymologyService` to improve performance and reduce unnecessary network requests. Subsequent or concurrent calls for the same word now share the same response, with normalization for case and whitespace.

💡 **What:** Added a `Map<string, Observable<string>>` cache and used `shareReplay(1)` on the HTTP observable.
🎯 **Why:** To prevent redundant network requests to the Wiktionary API, improving UI responsiveness and reducing server load.
📊 **Measured Improvement:** Verified via unit tests that a second call for the same word does not trigger an additional HTTP request.

---
*PR created automatically by Jules for task [5439089510488029540](https://jules.google.com/task/5439089510488029540) started by @snapfast*