### PR TITLE
🧪 Add Error Path and Success Path Tests for Etymology Search

### DIFF
--- a/src/app/component/home/home.component.spec.ts
+++ b/src/app/component/home/home.component.spec.ts
@@ -3,12 +3,15 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, throwError } from 'rxjs';
 
 import { HomeComponent } from './home.component';
+import { EtymologyService } from '../../service/etymology.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let etymologyService: EtymologyService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -16,18 +19,68 @@ describe('HomeComponent', () => {
       providers: [
         provideRouter([]),
         provideHttpClient(),
-        provideHttpClientTesting()
+        provideHttpClientTesting(),
+        EtymologyService
       ]
     })
     .compileComponents();
     
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
+    etymologyService = TestBed.inject(EtymologyService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('search', () => {
+    it('should update currentEtymology and history on success', () => {
+      const mockEtymology = 'Derived from Latin.';
+      spyOn(etymologyService, 'getEtymology').and.returnValue(of(mockEtymology));
+
+      component.searchTerm = 'test';
+      component.search();
+
+      expect(component.currentEtymology()).toBe(mockEtymology);
+      expect(component.history()).toContain('test');
+      expect(component.isLoading()).toBeFalse();
+      expect(component.error()).toBeNull();
+      expect(component.searchTerm).toBe('');
+    });
+
+    it('should update error and isLoading on failure', () => {
+      spyOn(etymologyService, 'getEtymology').and.returnValue(throwError(() => new Error('API Error')));
+
+      component.searchTerm = 'test';
+      component.search();
+
+      expect(component.error()).toBe('Failed to fetch etymology. Please try again.');
+      expect(component.isLoading()).toBeFalse();
+      expect(component.currentEtymology()).toBe('');
+    });
+
+    it('should not search if term is empty', () => {
+      const etymologySpy = spyOn(etymologyService, 'getEtymology');
+
+      component.searchTerm = '   ';
+      component.search();
+
+      expect(etymologySpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle history updates correctly (move existing to end)', () => {
+      spyOn(etymologyService, 'getEtymology').and.returnValue(of('some response'));
+
+      component.history.set(['apple', 'banana']);
+
+      component.search('apple');
+      expect(component.history()).toEqual(['banana', 'apple']);
+
+      component.search('cherry');
+      expect(component.history()).toEqual(['banana', 'apple', 'cherry']);
+    });
   });
 
   describe('handleWordClick', () => {


### PR DESCRIPTION
🎯 **What:** Addressed the missing error path coverage for the etymology search in `HomeComponent`.
📊 **Coverage:**
- Error path: Verifies `error` signal is set and `isLoading` is false when the service fails.
- Success path: Verifies `currentEtymology`, `history`, `isLoading`, and `searchTerm` are updated correctly.
- Edge cases: Handles empty/whitespace search terms and ensures duplicate words are moved to the end of the history array.
✨ **Result:** Significantly improved test reliability and coverage for the core search functionality in `HomeComponent`.

---
*PR created automatically by Jules for task [5061110382749637590](https://jules.google.com/task/5061110382749637590) started by @snapfast*