### PR TITLE
🧹 remove unused afterNextRender import from WordsComponent

### DIFF
--- a/src/app/component/words/words.component.ts
+++ b/src/app/component/words/words.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal, OnInit, OnDestroy, inject, ElementRef, viewChildren, effect, PLATFORM_ID, afterNextRender, computed, viewChild } from '@angular/core';
+import { Component, signal, OnInit, OnDestroy, inject, ElementRef, viewChildren, effect, PLATFORM_ID, computed, viewChild } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { EtymologyService } from '../../service/etymology.service';
 import { animate, stagger } from 'motion';


### PR DESCRIPTION
🎯 **What:** Removed the unused `afterNextRender` import from `src/app/component/words/words.component.ts`.
💡 **Why:** This improves maintainability and readability by removing dead code.
✅ **Verification:** Confirmed the import was unused, removed it, and verified that the project builds and all tests pass.
✨ **Result:** Cleaner codebase with no unused imports in `WordsComponent`.

---
*PR created automatically by Jules for task [13039673730042210451](https://jules.google.com/task/13039673730042210451) started by @snapfast*